### PR TITLE
Parse embedded configuration

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -41,6 +41,7 @@
 		</config-file>
 		<framework src="com.github.bolein:better-licensing:1.5.0" />
 		<framework src="com.github.bolein.better-apk-expansion:downloader_library:5.0.3" />
+		<framework src="com.google.code.gson:gson:2.8.5" />
 		<framework src="build-extras.gradle" custom="true" type="gradleReference" />
 		<source-file src="src/android/CorHttpd.java" target-dir="src/com/rjfun/cordova/httpd" />
 		<source-file src="src/android/AndroidFile.java" target-dir="src/com/rjfun/cordova/httpd" />

--- a/src/android/WebServer.java
+++ b/src/android/WebServer.java
@@ -40,6 +40,8 @@ public class WebServer extends NanoHTTPD {
 
 	private XAPKZipResourceFile expansionFile = null;
 
+	private String apkVersion = "1";
+
 	private ArrayList<String> activePaths = new ArrayList<>();
 
 	/**
@@ -84,6 +86,10 @@ public class WebServer extends NanoHTTPD {
 		if (DEBUG) Log.i(LOGTAG, "Parsed JSON config to tree");
 		if (rootNode.isJsonObject()) {
 			JsonObject root = rootNode.getAsJsonObject(); 
+
+			if (root.has("apkVersion")) {
+				this.apkVersion = root.get("apkVersion").getAsString();
+			}
 			
 			if (root.has("layout")) {
 				JsonElement layout = root.get("layout");  
@@ -128,16 +134,10 @@ public class WebServer extends NanoHTTPD {
 		// By design, Google libraries bundle both APK Expansions, if available, 
 		// into one XAPKZipResourceFile resource. Any file is requested is 
 		// looked up first in the patch APK, then the main.
-		this.expansionFile = XAPKExpansionSupport.getAPKExpansionZipFile(ctx, 1, 1);
+		int version = Integer.parseInt(this.apkVersion); 
+		this.expansionFile = XAPKExpansionSupport.getAPKExpansionZipFile(ctx, version, version);
 		if (null != this.expansionFile) {
 			if (DEBUG) Log.i(LOGTAG, "Expansion file: " + this.expansionFile.toString());
-
-			/* XAPKZipResourceFile.ZipEntryRO[] listing = this.expansionFile.getEntriesAt("assets/objects");
-
-			for (XAPKZipResourceFile.ZipEntryRO zipEntry: listing) {
-				if (DEBUG) Log.i(LOGTAG, zipEntry.mFileName);
-			} */
-
 		}
 	}
 

--- a/src/android/WebServer.java
+++ b/src/android/WebServer.java
@@ -3,6 +3,7 @@ package com.rjfun.cordova.httpd;
 import xapk.*;
 
 import org.apache.cordova.CordovaInterface;
+import com.google.code.gson;
 
 import java.io.File;
 import java.io.FileInputStream;

--- a/src/android/WebServer.java
+++ b/src/android/WebServer.java
@@ -18,7 +18,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.util.Arrays;
-import java.util.List;
 import java.util.ArrayList;
 import java.util.Hashtable;
 import java.util.Properties;
@@ -48,7 +47,7 @@ public class WebServer extends NanoHTTPD {
 	 * Hashtable mapping (String)FILENAME_EXTENSION -> (String)MIME_TYPE
 	 */
 	@SuppressWarnings("rawtypes")
-	private Hashtable mimeTypes = new Hashtable();
+	private Hashtable<String,String> mimeTypes = new Hashtable<>();
 	{
 		StringTokenizer st = new StringTokenizer("css		text/css " + "htm		text/html " + "html		text/html "
 				+ "xml		text/xml " + "txt		text/plain " + "asc		text/plain " + "gif		image/gif "
@@ -97,7 +96,7 @@ public class WebServer extends NanoHTTPD {
 
 				if (layoutNode.has("main")) {
 					JsonArray main = layoutNode.getAsJsonArray("main");
-					List<String> mainRecords = gson.fromJson(main, List.class);
+					String[] mainRecords = gson.fromJson(main, String[].class);
 					for (String mainEntry : mainRecords) {
 						if (DEBUG) Log.i(LOGTAG, mainEntry);
 						this.activePaths.add(mainEntry);
@@ -106,7 +105,7 @@ public class WebServer extends NanoHTTPD {
 
 				if (layoutNode.has("patch")) {
 					JsonArray patch = layoutNode.getAsJsonArray("patch");
-					List<String> patchRecords = gson.fromJson(patch, List.class);
+					String[] patchRecords = gson.fromJson(patch, String[].class);
 					for (String patchEntry : patchRecords) {
 						if (DEBUG) Log.i(LOGTAG, patchEntry);
 						this.activePaths.add(patchEntry);


### PR DESCRIPTION
This complements 
https://github.com/KanoComputing/kit-app-shell-cordova/pull/29

Kindly note that an expansion apk needs to also specify its own version number (doesn't have to be the same as the app apk: this is supplied by the Play Store the first time the expansion apk is uploaded).

*CAVEAT:* because the build generates and transfers `main`|`patch` apks (for test), there needs to be plenty of storage space on emulators, in order to prevent broken pipes and other issues with tubing. ~10G is a reasonable place to start.